### PR TITLE
updates_10_22: fixed install dependency issue, run targets and install doc 

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -77,15 +77,29 @@ This first defines the app to run (scriptDir), user email for login (userID), da
 
 ## 4. Deploy Web Application
 
-- To run a given configuration file and host the server, call the make command from that 
-   local module directory.  Examples linking to these calls also exist within the master
-   makefile at the oncoDev14 level.  
-   
-   >make oncoApp7777
-   
-   This calls oncoApp7777, kills the currently running server, changes directory to the 
-   local modules, and runs the local make command to launch the process:
-   
-	(cd Oncoscape/inst/scripts/apps/oncoscape/; make local;)
+### Running a Global Installation
 
+- To run a given configuration file and host the server, call the make command from that
+   local module directory.  Examples linking to these calls also exist within the master
+   makefile at the oncoDev14 level.
+
+   >make oncoApp7777
+
+   This calls oncoApp7777, kills the currently running server, changes directory to the
+   local modules, and runs the local make command to launch the process:
+
+        (cd Oncoscape/inst/scripts/apps/oncoscape/; make run;)
+
+### Running a Local Installation
+
+- To run a given configuration file and host the server, call the make command from that
+   local module directory.  Examples linking to these calls also exist within the master
+   makefile at the oncoDev14 level.
+
+   >make oncoAppLocal7777
+
+   This calls oncoApp7777, kills the currently running server, changes directory to the
+   local modules, and runs the local make command to launch the process:
+
+        (cd Oncoscape/inst/scripts/apps/oncoscape/; make runLocal;)
 

--- a/Oncoscape/inst/scripts/apps/oncoscape/makefile
+++ b/Oncoscape/inst/scripts/apps/oncoscape/makefile
@@ -1,4 +1,4 @@
-default: kill
+run: kill
 	which R
 	m4 -E index.pre > index.html
 	R CMD INSTALL ../../../..
@@ -8,7 +8,7 @@ default: kill
 kill:
 	- kill -9 `ps aux | grep runOncoscapeApp-7777 | egrep -v grep | awk  '{print $$2}'`
 
-local: kill
+runLocal: kill
 	which R
 	m4 -E index.pre > index.html
 	R CMD INSTALL -l $(R_LIBS) ../../../..

--- a/installRpackages_global.sh
+++ b/installRpackages_global.sh
@@ -2,11 +2,7 @@
 # run with . ./setupLocalR.sh to prevent forking a subshell
 Rscript installBioconductorPackages.R
 
-cd analysisPackages
-R  --vanilla CMD INSTALL --no-test-load --no-lock PCA
-R  --vanilla CMD INSTALL --no-test-load --no-lock PLSR
- 
-cd ../dataPackages
+cd dataPackages
 R  --vanilla CMD INSTALL --no-test-load --no-lock PatientHistory
 R  --vanilla CMD INSTALL --no-test-load --no-lock SttrDataPackage
 R  --vanilla CMD INSTALL --no-test-load --no-lock DEMOdz
@@ -15,6 +11,10 @@ R  --vanilla CMD INSTALL --no-test-load --no-lock TCGAlgg
 R  --vanilla CMD INSTALL --no-test-load --no-lock TCGAbrain
 R  --vanilla CMD INSTALL --no-test-load --no-lock DGI
 
+cd ../analysisPackages
+R  --vanilla CMD INSTALL --no-test-load --no-lock PCA
+R  --vanilla CMD INSTALL --no-test-load --no-lock PLSR
+ 
 cd ../Oncoscape
 R  --vanilla CMD INSTALL --no-test-load --no-lock .
 

--- a/installRpackages_local.sh
+++ b/installRpackages_local.sh
@@ -2,11 +2,7 @@
 # run with . ./setupLocalR.sh to prevent forking a subshell
 Rscript installBioconductorPackages.R
 
-cd analysisPackages
-R  --vanilla CMD INSTALL -l $R_LIBS --no-test-load --no-lock PCA
-R  --vanilla CMD INSTALL -l $R_LIBS --no-test-load --no-lock PLSR
- 
-cd ../dataPackages
+cd dataPackages
 R  --vanilla CMD INSTALL -l $R_LIBS --no-test-load --no-lock PatientHistory
 R  --vanilla CMD INSTALL -l $R_LIBS --no-test-load --no-lock SttrDataPackage
 R  --vanilla CMD INSTALL -l $R_LIBS --no-test-load --no-lock DEMOdz
@@ -15,6 +11,10 @@ R  --vanilla CMD INSTALL -l $R_LIBS --no-test-load --no-lock TCGAlgg
 R  --vanilla CMD INSTALL -l $R_LIBS --no-test-load --no-lock TCGAbrain
 R  --vanilla CMD INSTALL -l $R_LIBS --no-test-load --no-lock DGI
 
+cd ../analysisPackages
+R  --vanilla CMD INSTALL -l $R_LIBS --no-test-load --no-lock PCA
+R  --vanilla CMD INSTALL -l $R_LIBS --no-test-load --no-lock PLSR
+ 
 cd ../Oncoscape
 R  --vanilla CMD INSTALL -l $R_LIBS --no-test-load --no-lock .
 

--- a/makefile
+++ b/makefile
@@ -58,14 +58,8 @@ installOncoscapeLocal:
 #   kills current process and starts new one
 #   runs Oncoscape on port 7777 with DEMOdz & TCGAgbm
 #   using all (9) current tabs
+oncoAppLocal7777:
+	(cd Oncoscape/inst/scripts/apps/oncoscape/; make runLocal;)
+
 oncoApp7777:
-	(cd Oncoscape/inst/scripts/apps/oncoscape/; make local;)
-
-# oncoApp7788: kills then launches R server: public Brain datasets on port 7777
-####
-#   kills current process and starts new one
-#   runs Oncoscape on port 7788 with DEMOdz & TCGAgbm
-#   using all (9) current tabs
-oncoApp7788:
-	(cd Oncoscape/inst/scripts/apps/oncotest/; make local;)
-
+	(cd Oncoscape/inst/scripts/apps/oncoscape/; make run;)


### PR DESCRIPTION
##### This fixes the dependency order issue on clean installs by switching analysis and data package order. 
- Fixes #36

##### Adjusted the main make file:
- Global:  make install; make oncoApp7777
- Local: make installLocal;  make oncoAppLocal7777 

##### Adjusted Oncoscape/inst/scripts/apps/oncoscape/makefile:
- Made 'run' and 'runLocal' targets to match "install" and "installLocal" 

##### Updated "Deploy" section of the INSTALL.md to reflect the global / local run instructions