### PR TITLE
updates_develop_10_22: fixed install dependency issue, run targets and install doc for the development branch

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,105 @@
+# Install
+
+These instructions describe how to install and run Oncoscape with the necessary data, 
+analysis, and R dependency packages.  
+
+1. System Requirements
+2. Build From Source
+3. Runtime Configuration
+4. Deploy Web Application
+
+
+## 1. System Requirements
+
+- Install R from https://cran.r-project.org/
+	
+- Create directory to store persistent information:
+	  Replace <path/to/directory> with where you would like to store R metadata attached
+	  to your login account.
+	  
+	  >nano ~/.bash_profile
+	  
+	add the following line:
+  
+  	>export ONCOSCAPE_USER_DATA_STORE=file:///\<path/to/directory\>
+
+## 2. Build From Source
+
+- To install within the default R library, call "install" from the makefile.
+
+=======
+
+- To install within the default R library, call "install" from the makefile.
+
+	>make install
+
+(optional) Local installation of R packages
+To install and run Oncoscape locally, explicitly define the R path and directory of the
+working library $R_LIBS.  One method is to create a bash configuration file defining the
+necessary environment variables.  In this case we create a file called .setupR and 
+prioritize /usr/bin/R as the R executable and Rlibs/x86_64-unknown-linux-gnu-library/3.2
+as the R library.  Note that the full path should be used instead of referencing a  \<cwd\>.
+ 	
+ 	>vi .setupR
+		PATH=/usr/bin/R:$PATH
+		export R_LIBS= <cwd>/Rlibs/x86_64-unknown-linux-gnu-library/3.2
+
+ 	>source .setupR
+ 	>which R
+ 	>echo $R_LIBS
+ 
+ This file will need to be called from the terminal before any update, installation, or 
+ execution to ensure the proper directory structure is accessed.
+
+- To install within the local $R_LIBS directory, call "installLocal" from the makefile.
+
+	>make installLocal
+	
+
+## 3. Runtime Configuration
+
+Configuration files are saved within the Oncoscape module from which they run.
+For example, see Oncoscape/inst/scripts/apps/oncoscape/runOncoscapeApp-7777.R
+This first defines the app to run (scriptDir), user email for login (userID), datasets to load 
+(current.datasets), and port to host (port), then launches Oncoscape within the browser.
+
+	library(OncoDev14)
+	scriptDir <- "apps/oncoscape"
+	stopifnot(nchar(Sys.getenv("ONCOSCAPE_USER_DATA_STORE")) > 0)
+	userID <- "test@nowhere.org"
+	current.datasets <- c("DEMOdz")
+	port <- 11005
+	onco <- OncoDev14(port=port, scriptDir=scriptDir, userID=userID, datasetNames=current.datasets)
+	if(Sys.info()[["nodename"]] != "lopez") 
+	   browseURL(sprintf("http://localhost:%d", port))
+	run(onco)
+
+
+## 4. Deploy Web Application
+
+### Running a Global Installation
+
+- To run a given configuration file and host the server, call the make command from that
+   local module directory.  Examples linking to these calls also exist within the master
+   makefile at the oncoDev14 level.
+
+   >make oncoApp7777
+
+   This calls oncoApp7777, kills the currently running server, changes directory to the
+   local modules, and runs the local make command to launch the process:
+
+        (cd Oncoscape/inst/scripts/apps/oncoscape/; make run;)
+
+### Running a Local Installation
+
+- To run a given configuration file and host the server, call the make command from that
+   local module directory.  Examples linking to these calls also exist within the master
+   makefile at the oncoDev14 level.
+
+   >make oncoAppLocal7777
+
+   This calls oncoApp7777, kills the currently running server, changes directory to the
+   local modules, and runs the local make command to launch the process:
+
+        (cd Oncoscape/inst/scripts/apps/oncoscape/; make runLocal;)
+

--- a/Oncoscape/inst/scripts/apps/oncoscape/makefile
+++ b/Oncoscape/inst/scripts/apps/oncoscape/makefile
@@ -1,4 +1,4 @@
-default: kill
+run: kill
 	which R
 	m4 -E index.pre > index.html
 	R CMD INSTALL ../../../..
@@ -8,7 +8,7 @@ default: kill
 kill:
 	- kill -9 `ps aux | grep runOncoscapeApp-7777 | egrep -v grep | awk  '{print $$2}'`
 
-local: kill
+runLocal: kill
 	which R
 	m4 -E index.pre > index.html
 	R CMD INSTALL -l $(R_LIBS) ../../../..

--- a/installRpackages_global.sh
+++ b/installRpackages_global.sh
@@ -2,11 +2,7 @@
 # run with . ./setupLocalR.sh to prevent forking a subshell
 Rscript installBioconductorPackages.R
 
-cd analysisPackages
-R  --vanilla CMD INSTALL --no-test-load --no-lock PCA
-R  --vanilla CMD INSTALL --no-test-load --no-lock PLSR
- 
-cd ../dataPackages
+cd dataPackages
 R  --vanilla CMD INSTALL --no-test-load --no-lock PatientHistory
 R  --vanilla CMD INSTALL --no-test-load --no-lock SttrDataPackage
 R  --vanilla CMD INSTALL --no-test-load --no-lock DEMOdz
@@ -15,6 +11,10 @@ R  --vanilla CMD INSTALL --no-test-load --no-lock TCGAlgg
 R  --vanilla CMD INSTALL --no-test-load --no-lock TCGAbrain
 R  --vanilla CMD INSTALL --no-test-load --no-lock DGI
 
+cd ../analysisPackages
+R  --vanilla CMD INSTALL --no-test-load --no-lock PCA
+R  --vanilla CMD INSTALL --no-test-load --no-lock PLSR
+ 
 cd ../Oncoscape
 R  --vanilla CMD INSTALL --no-test-load --no-lock .
 

--- a/installRpackages_local.sh
+++ b/installRpackages_local.sh
@@ -2,11 +2,7 @@
 # run with . ./setupLocalR.sh to prevent forking a subshell
 Rscript installBioconductorPackages.R
 
-cd analysisPackages
-R  --vanilla CMD INSTALL -l $R_LIBS --no-test-load --no-lock PCA
-R  --vanilla CMD INSTALL -l $R_LIBS --no-test-load --no-lock PLSR
- 
-cd ../dataPackages
+cd dataPackages
 R  --vanilla CMD INSTALL -l $R_LIBS --no-test-load --no-lock PatientHistory
 R  --vanilla CMD INSTALL -l $R_LIBS --no-test-load --no-lock SttrDataPackage
 R  --vanilla CMD INSTALL -l $R_LIBS --no-test-load --no-lock DEMOdz
@@ -15,6 +11,10 @@ R  --vanilla CMD INSTALL -l $R_LIBS --no-test-load --no-lock TCGAlgg
 R  --vanilla CMD INSTALL -l $R_LIBS --no-test-load --no-lock TCGAbrain
 R  --vanilla CMD INSTALL -l $R_LIBS --no-test-load --no-lock DGI
 
+cd ../analysisPackages
+R  --vanilla CMD INSTALL -l $R_LIBS --no-test-load --no-lock PCA
+R  --vanilla CMD INSTALL -l $R_LIBS --no-test-load --no-lock PLSR
+ 
 cd ../Oncoscape
 R  --vanilla CMD INSTALL -l $R_LIBS --no-test-load --no-lock .
 

--- a/makefile
+++ b/makefile
@@ -59,14 +59,8 @@ installOncoscapeLocal:
 #   kills current process and starts new one
 #   runs Oncoscape on port 7777 with DEMOdz & TCGAgbm
 #   using all (9) current tabs
+oncoAppLocal7777:
+	(cd Oncoscape/inst/scripts/apps/oncoscape/; make runLocal;)
+
 oncoApp7777:
-	(cd Oncoscape/inst/scripts/apps/oncoscape/; make local;)
-
-# oncoApp7788: kills then launches R server: public Brain datasets on port 7777
-####
-#   kills current process and starts new one
-#   runs Oncoscape on port 7788 with DEMOdz & TCGAgbm
-#   using all (9) current tabs
-oncoApp7788:
-	(cd Oncoscape/inst/scripts/apps/oncotest/; make local;)
-
+	(cd Oncoscape/inst/scripts/apps/oncoscape/; make run;)


### PR DESCRIPTION
##### This fixes the dependency order issue on clean installs by switching analysis and data package order. 
- Fixes #36 for the development branch

##### Adjusted the main make file:
- Global:  make install; make oncoApp7777
- Local: make installLocal;  make oncoAppLocal7777 

##### Adjusted Oncoscape/inst/scripts/apps/oncoscape/makefile:
- Made 'run' and 'runLocal' targets to match "install" and "installLocal" 

##### Added INSTALL.md file with updated "Deploy" section to reflect the global / local run instructions