### PR TITLE
change devel run-oncoscape7777 with all datasets

### DIFF
--- a/Oncoscape/inst/scripts/apps/oncoscape/runOncoscapeApp-7777.R
+++ b/Oncoscape/inst/scripts/apps/oncoscape/runOncoscapeApp-7777.R
@@ -3,7 +3,7 @@ sessionInfo()
 scriptDir <- "apps/oncoscape"
 stopifnot(nchar(Sys.getenv("ONCOSCAPE_USER_DATA_STORE")) > 0)
 userID <- "test@nowhere.org"
-current.datasets <- c("TCGAgbm;TCGAbrain")
+current.datasets <- c("DEMOdz;TCGAgbm;TCGAlgg;TCGAbrain;TCGAbrca;TCGAprad;TCGAlusc;TCGAluad;TCGAlung;TCGAhnsc;TCGAcoadread")
 port <- 7777
 onco <- OncoDev14(port=port, scriptDir=scriptDir, userID=userID, datasetNames=current.datasets)
 if(Sys.info()[["nodename"]] != "lopez") 


### PR DESCRIPTION
runDocker command uses the oncoscape app directory, which just includes the brain data.  standardizing so separate targets not necessary to include port number