### PR TITLE
dynamically load and construct data, dashboard page

### DIFF
--- a/Oncoscape/R/OncoDev14.R
+++ b/Oncoscape/R/OncoDev14.R
@@ -77,19 +77,22 @@ toJSON <- function(..., auto_unbox = TRUE)
    datasetNames <- strsplit(datasetNames, ";")[[1]]
    for(datasetName in datasetNames){
      printf("OncoDev14:.loadDataPackages: %s", datasetName);
-     s <- sprintf("require(%s, quietly=TRUE)", datasetName)
-     tryCatch(eval(parse(text=s)), error=function(e) {
-        message(sprintf("failed to load dataset '%s'", datasetName))
-        })
-     if(exists(datasetName)){
+        eval(parse(text= sprintf("datasets[['%s']] <- SttrDataPackage()", datasetName)))
+        message(sprintf("OncoDev14 loading: %s", datasetName))
+
+#     s <- sprintf("require(%s, quietly=TRUE)", datasetName)
+#     tryCatch(eval(parse(text=s)), error=function(e) {
+#        message(sprintf("failed to load dataset '%s'", datasetName))
+#        })
+#     if(exists(datasetName)){
 #        s <- sprintf("datasets[['%s']] <- %s(key=%s)", datasetName, datasetName, encryptedKey)
-        s <- sprintf("datasets[['%s']] <- %s()", datasetName, datasetName)
-        duration <- system.time(tryCatch(eval(parse(text=s)),
-                                error=function(e)
-                                message(sprintf("failure calling constructor for '%s'", datasetName))))[["elapsed"]]
-        message(sprintf("OncoDev14 loading: %40s %7.2f seconds", s, duration))
-        message(sprintf("  new list of loaded datasets: %s", paste(ls(datasets), collapse=",")))
-        } # if data package successfully loaded, ctor defined
+#        s <- sprintf("datasets[['%s']] <- %s()", datasetName, datasetName)
+#        duration <- system.time(tryCatch(eval(parse(text=s)),
+#                                error=function(e)
+#                                message(sprintf("failure calling constructor for '%s'", datasetName))))[["elapsed"]]
+#        message(sprintf("OncoDev14 loading: %40s %7.2f seconds", s, duration))
+#        message(sprintf("  new list of loaded datasets: %s", paste(ls(datasets), collapse=",")))
+#        } # if data package successfully loaded, ctor defined
      } # for datasetName
 
    printf("=== datsets now available in datasets environment: %s", paste(ls(datasets), collapse=","))

--- a/Oncoscape/R/wsDatasets.R
+++ b/Oncoscape/R/wsDatasets.R
@@ -47,6 +47,27 @@ getAllDataSetNames <- function(ws, msg)
 
 } # getAllDataSetNames
 #----------------------------------------------------------------------------------------------------
+.loadDataset <- function(datasetName)
+{
+  available.datasets <- ls(datasets)
+  printf("wsDatasets.R, specifyCurrentDataset, available: %s",
+         paste(available.datasets, collapse=";"));
+  
+  stopifnot(datasetName %in% available.datasets);
+  require(datasetName, character.only=TRUE)
+
+  constructionNeeded <- !datasetName %in% ls(state)
+  printf("%s construction needed? %s", datasetName, constructionNeeded);
+  if(constructionNeeded){
+     printf("wsDatasets.specifyCurrentDataset creating and storing a new %s object", datasetName);
+     eval(parse(text=sprintf("ds <- %s()", datasetName)))
+     datasets[[datasetName]] <- ds
+	 state[[datasetName]] <- datasetName;
+
+     } # creating and storing new instance
+
+} # .loadDataset
+#----------------------------------------------------------------------------------------------------
 specifyCurrentDataset <- function(ws, msg)
 {
   available.datasets <- ls(datasets)
@@ -54,19 +75,9 @@ specifyCurrentDataset <- function(ws, msg)
          paste(available.datasets, collapse=";"));
   
   dataset <- msg$payload
+  .loadDataset(dataset)
 
-  stopifnot(dataset %in% available.datasets);
-  state[["currentDatasetName"]] <- dataset;
-  require(dataset, character.only=TRUE)
-
-  constructionNeeded <- !dataset %in% ls(state)
-  printf("%s construction needed? %s", dataset, constructionNeeded);
-  if(constructionNeeded){
-     printf("wsDatasets.specifyCurrentDataset creating and storing a new %s object", dataset);
-     eval(parse(text=sprintf("ds <- %s()", dataset)))
-     state[[dataset]] <- ds
-     } # creating and storing new instance
-
+  state[["currentDatasetName"]] <- dataset;  
   payload <- getDataManifestAsJSON(dataset)
   return.msg <- list(cmd=msg$callback, status="success", callback="",
                      payload=payload)
@@ -101,6 +112,9 @@ getDataManifest <- function(ws, msg)
 {
   datasetName <- msg$payload;
 
+  if(datasetName %in% ls(datasets) && !datasetName %in% ls(state)){
+     .loadDataset(datasetName)
+  }
   if(!datasetName %in% ls(datasets)){
      return.msg <- list(cmd=msg$callback, status="error", callback="",
                         payload=sprintf("unknown dataset '%s'", datasetName))

--- a/Oncoscape/R/wsPCA.R
+++ b/Oncoscape/R/wsPCA.R
@@ -27,7 +27,7 @@ ws.createPCA <- function(ws, msg)
    print(msg)
    
    currentDataSetName <- state[["currentDatasetName"]]
-   ds <- state[[currentDataSetName]];
+   ds <- datasets[[currentDataSetName]];
    matrixName = msg$payload$matrixName
    cmd <- sprintf("mypca <- PCA(ds, '%s')", matrixName);
    eval(parse(text=cmd))

--- a/Oncoscape/R/wsPLSR.R
+++ b/Oncoscape/R/wsPLSR.R
@@ -13,10 +13,10 @@ createPLSR <- function(ws, msg)
    printf("    callback: %s", msg$callback)
    print(msg$payload)
 
-   dataPackageName = msg$payload$dataPackage
+#   dataPackageName = msg$payload$dataPackage
    matrixName = msg$payload$matrixName
 
-   printf("    dataPackageName: %s", dataPackageName);
+#   printf("    dataPackageName: %s", dataPackageName);
    printf("         matrixName: %s", matrixName);
    
    #require(dataPackageName, character.only=TRUE)

--- a/Oncoscape/R/wsPLSR.R
+++ b/Oncoscape/R/wsPLSR.R
@@ -24,7 +24,7 @@ createPLSR <- function(ws, msg)
       # this creates a real variable, ds, which is an object of whatever dataSetName names
 
    currentDataSetName <- state[["currentDatasetName"]]
-   ds <- state[[currentDataSetName]];
+   ds <- datasets[[currentDataSetName]];
    cmd <- sprintf("myplsr <- PLSR(ds, '%s')", matrixName);
    printf("createPLSR about to eval cmd: %s", cmd)
    eval(parse(text=cmd))

--- a/Oncoscape/R/wsTimelines.R
+++ b/Oncoscape/R/wsTimelines.R
@@ -13,7 +13,9 @@ createTimelines <- function(ws, msg)
    print(msg$payload)
 
    currentDataSetName <- state[["currentDatasetName"]]
-   ds <- state[[currentDataSetName]];
+   printf("    using current Dataset: %s", currentDataSetName)
+
+   ds <- datasets[[currentDataSetName]];
    events <- getEventList(ds)
    pts <- getPatientList(ds)
    eventTypes <- getEventTypeList(ds)

--- a/Oncoscape/inst/scripts/Dashboard/Module.js
+++ b/Oncoscape/inst/scripts/Dashboard/Module.js
@@ -1,0 +1,108 @@
+//----------------------------------------------------------------------------------------------------
+var DashboardModule = (function () {
+
+  var HIDRAlink = "<a href='http://www.fhcrc.org/en/labs/hidra.html' name='newWindow'>HIDRA</a>"
+
+  var TCGAdatalink = "<a href='https://tcga-data.nci.nih.gov/tcga/tcgaCancerDetails.jsp?diseaseType=GBM&diseaseid=Glioblastoma%20multiforme' name='newWindow'>TCGA portal</a>"
+
+  var GBM2013paper = "<a href='http://www.ncbi.nlm.nih.gov/pubmed/24120142' name='newWindow'>(Brennan et al, Cell 2013)</a>"
+
+//----------------------------------------------------------------------------------------------------
+function isIE () {
+  var myNav = navigator.userAgent.toLowerCase();
+  return (myNav.indexOf('msie') != -1) ? parseInt(myNav.split('msie')[1]) : false;
+}
+//----------------------------------------------------------------------------------------------------
+
+function DashboardInitializeUI(){
+        
+        console.log(navigator.userAgent)
+        //if(navigator.userAgent.indexOf("Chrome/3") < 0){
+        //  alert("To display networks reliably, Chrome v37 or later is required. Please switch or upgrade.");
+        //  }
+
+        console.log("===== Display User Information")        
+
+        $("#DashboardAccordion" ).accordion({
+              active: false,
+              heightStyle: "content",
+              collapsible: true,
+              icons: null
+              });
+            
+        $("#AvailableDataAccordian" ).accordion({
+              active: false,
+              heightStyle: "content",
+              collapsible: true,
+              icons: null
+        });
+
+        LoadDatainfo();
+        document.getElementsByName("newWindow").onclick = function(){
+                var thisIsIt = 1
+                  return !window.open(this.href);
+        }
+            
+       /* $('a').each(function() {
+              var a = new RegExp('/' + window.location.host + '/');
+              if(!a.test(this.href)) {
+                 $(this).click(function(event) {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        window.open(this.href, '_blank');
+                  });
+               }
+        }); */
+               
+    };
+//----------------------------------------------------------------------------------------------------
+function LoadDatainfo(){
+ 
+      var TCGAdata =  $("#TCGAdataInfo")
+      TCGAdata.append("<p><h4 align=center>Glioblastoma multiforme (GBM) Pilot demo</h4></p>")
+      TCGAdata.append("<p>Copy Number Alterations, Single Nucleotide Alterations, indels and patient histories were downloaded from the " +
+                      TCGAdatalink + ", based off the 2013 publication "+GBM2013paper+" and supplemented by in-house data.</p>")          
+          
+      TCGAdata.append("<div id='TCGArnadata'><p>The TCGA GBM expression data included in Oncoscape is for 304 patients that meet the following criteria:<br>" +
+           "<ol type='A'><li>TCGA clinical data has (529 GBM samples) <ul> <li>'histologic type' is 'GBM'</li><li>'sample type' is 'primary'</li><li>an assigned expression subtype (ie not empty)</li></ul>"+
+           "<li>TCGA expression data within unified (Agilent + Affymetrix) set defined in comparative paper (PMID:21436879)  (323 GBM samples).</li></ol>"+
+           "</p></div>")
+ 
+      var UWMSCCAdata =  $("#UWMSCCAdataInfo")
+      UWMSCCAdata.append("<p>Access to information regarding <a href='http://www.uwmedicine.org/' name='newWindow'>University of Washington Medicine</a> and <a href='http://www.seattlecca.org/'  name='newWindow'>SCCA</a> patients is restricted by IRB approval.  Please contact <a href='http://www.fhcrc.org/en/diseases/featured-researchers/fearn-paul.html'  name='newWindow'>Paul Fearn</a> for questions regarding access.</p>")
+
+      var TableContents = $("#TableContentsDiv")
+      TableContents.append("<p><h4>Patient History:</h4> Table view of patient information.  Filter data by Age of Diagnosis & survival sliders or by specific search terms.</p>")
+      TableContents.append("<p><h4>Patient Timelines:</h4> Visual representation of patient histories.  Align or Order patient histories by clinical events.  Couple features (e.g. time to progression, histology type, or age at diagnosis) with patient timelines. </p>")
+      TableContents.append("<p><h4>Principle Component Analysis (PCA):</h4> Two dimensional view of per sample expression data.</p>")
+      TableContents.append("<p><h4>Partial Least Squares Regression (PLSR):</h4> Use linear regression to correlate genes with clinical features using RNA expression </p>")
+      TableContents.append("<p><h4>GBM Pathways:</h4> Map patient specific expression levels on a hand curated network of genes associated with GBM.  Click on edges to view the abstracts defining the relationship. </p>")   
+//      TableContents.append("<p><h4>Angiogenesis:</h4> Map patient specific expression levels on a small network of genes associated with angiogenesis.  Click on edges to view the abstracts defining the relationship. </p>")   
+      TableContents.append("<p><h4>Markers & Patients:</h4> Link copy number variation and mutation data to patients grouped by GBM classification: mesenchymal, classical, neural, proneural, and G-CIMP </p>")
+//      TableContents.append("<p><h4>Distributions:</h4> Plot clinical features of defined populations. </p>")
+      TableContents.append("<p><h4>Survival:</h4> Compare survival rates of selected patients against the remaining population in a Kaplan Meier plot.</p>")
+
+      var AboutOncoscape = $("#AboutOncoscapeDiv")
+      AboutOncoscape.append("<p>Oncoscape is developed at the <a href= 'http://www.fhcrc.org' name='newWindow'>Fred Hutchinson Cancer Research Center</a> under the auspices of the <a href='http://www.sttrcancer.org' name='newWindow'>Solid Tumor Translational Research</a> initiative.</p>")
+      AboutOncoscape.append("<p> Oncoscape is a web-based, menu-driven analysis and visualization platform for large-scale, heterogeneous clinical and molecular patient timeline data as exemplified by the <a href='http://www.fhcrc.org/en/labs/hidra.html'  name='newWindow'>Fred Hutch HIDRA</a> database.</p>")
+      AboutOncoscape.append("<p>Oncoscape was conceived, and is managed, by a Steering Committee comprising: <a href='http://www.fhcrc.org/en/diseases/featured-researchers/holland-eric.html' name='newWindow'>Eric Holland</a>, <a href='http://www.sttrcancer.org/en/contact-us.html'  name='newWindow'>Desert Horse-Grant</a>, <a href='http://www.fhcrc.org/en/diseases/featured-researchers/fearn-paul.html'  name='newWindow'>Paul Fearn</a>, <a href='http://fhcrc.academia.edu/PaulShannon'  name='newWindow'>Paul Shannon</a>,<a href='http://www.researchgate.net/profile/Lisa_McFerrin' name='newWindow'>Lisa McFerrin</a>, and <a href='http://research.fhcrc.org/bolouri/' name='newWindow'>Hamid Bolouri</a>.</p>")
+
+      AboutOncoscape.append("<p> Paul Shannon (lead) and Lisa McFerrin are the primary developers of Oncoscape, with additional code contributions by Cliff Rostomily and Hamid Bolouri.</p>")
+
+   }
+
+//----------------------------------------------------------------------------------------------------
+return{
+
+   init: function(){
+      hub.addOnDocumentReadyFunction(DashboardInitializeUI);
+      
+      }
+   };
+
+}); // DateAndTimeModule
+//----------------------------------------------------------------------------------------------------
+Dashboard = DashboardModule();
+Dashboard.init();
+
+hub.registerModule("Dashboard", Dashboard);

--- a/Oncoscape/inst/scripts/Dashboard/index.pre
+++ b/Oncoscape/inst/scripts/Dashboard/index.pre
@@ -1,0 +1,10 @@
+include(../index.common)
+include(../common.js)
+include(../UserSettings.js)
+include(../experiment/AboutLink/Module.js)
+include(Module.js)
+<body>
+include(../experiment/AboutLink/widget.html)
+include(widget.html)
+</body>
+</html>

--- a/Oncoscape/inst/scripts/Dashboard/makefile
+++ b/Oncoscape/inst/scripts/Dashboard/makefile
@@ -1,0 +1,11 @@
+
+devel:
+	m4 index.pre > index.html
+	R CMD install --no-test-load --no-lock ../../..
+	R -f runDevel.R
+release:
+	m4 index.pre > index.html
+	R CMD install --no-test-load --no-lock ../../..
+	R -f run.R
+
+

--- a/Oncoscape/inst/scripts/Dashboard/run.R
+++ b/Oncoscape/inst/scripts/Dashboard/run.R
@@ -1,0 +1,2 @@
+library(Oncoscape)
+startWebApp("Dashboard/index.html", port=7178L)

--- a/Oncoscape/inst/scripts/Dashboard/runDevel.R
+++ b/Oncoscape/inst/scripts/Dashboard/runDevel.R
@@ -1,0 +1,3 @@
+library(OncoDev)
+port=7012L
+startWebApp("Dashboard/index.html", package="OncoDev", port=port)

--- a/Oncoscape/inst/scripts/Dashboard/widget.html
+++ b/Oncoscape/inst/scripts/Dashboard/widget.html
@@ -16,7 +16,7 @@ ul.UserDocs {
 -->
 
    <div align="center" class="jumbotron"> 
-       <div id="oncoscapeLogo" >	<img width="375" src="http://oncoscape.sttrcancer.org/oncoscape/images/oncoscape_logo_TM.png" alt="Oncoscape"/></div>
+       <div id="oncoscapeLogo" >	<img width="375" src="http://oncoscape.sttrcancer.org/oncoscape/images/oncoscape_logo_FINAL.png" alt="Oncoscape"/></div>
 
        <span> (version 1.4.93, December 10th, 2015)<br></span>
        <p> <font color="red">This website is undergoing frequent modification.  <br> User beware!</font></p>

--- a/Oncoscape/inst/scripts/Dashboard/widget.html
+++ b/Oncoscape/inst/scripts/Dashboard/widget.html
@@ -1,0 +1,107 @@
+<style>
+ul.UserDocs {
+    list-style-type: circle;
+}
+
+</style>
+
+<div id="DashboardDiv" class="container">
+   <a href="https://github.com/FredHutch/Oncoscape" target="_blank" ><img style="position: absolute; top: 0; right: 0; border: 0;" 
+   src="https://camo.githubusercontent.com/a6677b08c955af8400f44c6298f40e7d19cc5b2d/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f677261795f3664366436642e706e67"
+    alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png"></a>
+<!--    	<span id="InfoLogo_pathways" style="float:right">
+          <img height="50" src="http://oncoscape.sttrcancer.org/oncoscape/images/oncoscape_thumb.png"
+          alt="Info" data-canonical-src="http://oncoscape.sttrcancer.org/oncoscape/images/oncoscape_thumb.png">
+        </span>
+-->
+
+   <div align="center" class="jumbotron"> 
+       <div id="oncoscapeLogo" >	<img width="375" src="http://oncoscape.sttrcancer.org/oncoscape/images/oncoscape_logo_TM.png" alt="Oncoscape"/></div>
+
+       <span> (version 1.4.93, December 10th, 2015)<br></span>
+       <p> <font color="red">This website is undergoing frequent modification.  <br> User beware!</font></p>
+   </div>   
+ 
+   <center><p> Oncoscape works best with the latest Chrome browser, and a high resolution screen. </p></center>
+
+       
+	 <div id="DashboardAccordion">
+		<h3 class="panel-title" style="margin-bottom:0px">
+			<a class="collapsed" data-toggle="collapse" data-parent="#DashboardAccordion" href="#collapse1" aria-expanded="true" aria-controls="collapse1">
+			  Available Data 
+			</a>
+		</h3>
+		<div id="collapse1">
+		   <div id="AvailableDataAccordian">     
+		   <h3 class="panel-title" style="margin-bottom:0px">
+			<a data-toggle="collapse" data-parent="#collapse1" href="#collapse11" aria-expanded="true" aria-controls="collapse11">
+			  TCGA: The Cancer Genome Atlas
+			</a>
+		  </h3>
+		  <div id="TCGAdataInfo" class="panel-body"></div>
+  
+		  <h3 class="panel-title" style="margin-bottom:0px">
+			<a data-toggle="collapse" data-parent="#collapse1" href="#collapse22" aria-expanded="true" aria-controls="collapse22">
+			  Restricted Data
+			</a>
+		  </h3>
+		   <div id="collapse22" class="panel-collapse collapse" role="tabpanel" aria-labelledby="heading22">
+			  <div id="UWMSCCAdataInfo" class="panel-body"> </div>      
+		   </div>
+		</div>
+	 </div>
+ 
+		<h3 class="panel-title" style="margin-bottom:0px">
+			<a class="collapsed " data-toggle="collapse" data-parent="#DashboardAccordion" href="#collapse2" aria-expanded="true" aria-controls="collapse2">
+			  Table of Contents
+			</a>
+		 </h3>
+		<div id="collapse2" class="panel-collapse collapse" role="tabpanel" aria-labelledby="heading2">
+		  <div id="TableContentsDiv" class="panel-body"></div>
+		</div>
+  
+		<h3 class="panel-title" style="margin-bottom:0px">
+			<a  class="collapsed " data-toggle="collapse" data-parent="#DashboardAccordion" href="#collapse3" aria-expanded="true" aria-controls="collapse3">
+			  Features To Come...
+			</a>
+		  </h3>
+		<div id="collapse3" class="panel-collapse collapse" role="tabpanel" aria-labelledby="heading3">
+		  <ul id="FeaturesToCome">
+				  <li> Saved Selections </li>
+				  <li> Interactive Kaplan Meier Plots </li>
+				  <li> Expression subtyping tool </li>
+				  <li> Expression correlation to TCGA samples using MDS </li>
+				  <li> Tool to find TCGA samples with similar mutational profiles </li>
+				  <li> Expression clustering and heatmaps </li>
+				  <li> Gene set enrichment analysis for user-selected groups </li>
+				  <li> Differential expression analysis for user-selected groups </li>
+				  <li> Hallmarks of Cancer </li>
+			   </ul>
+		  </div>
+  
+		<h3 class="panel-title" style="margin-bottom:0px">
+			<a class="collapsed " data-toggle="collapse" data-parent="#DashboardAccordion" href="#collapse4" aria-expanded="false" aria-controls="collapse4">
+			  About Oncoscape
+			</a>
+		  </h3>
+		<div id="collapse4" class="panel-collapse collapse" role="tabpanel" aria-labelledby="heading4">
+		  <div  id="AboutOncoscapeDiv" class="panel-body"></div>
+		</div>
+  
+		<h3 class="panel-title" style="margin-bottom:0px">
+			<a class="collapsed " data-toggle="collapse" data-parent="#DashboardAccordion" href="#collapse5" aria-expanded="false" aria-controls="collapse5">
+			  Terms Of Use
+			</a>
+		  </h3>
+		<div id="collapse5" class="panel-collapse collapse" role="tabpanel" aria-labelledby="heading5">
+		  <div  id="LegalNotice" class="panel-body">
+			<p>
+				Oncoscape source code is freely available via <a href="http://github.com/oncoscape" name='newWindow'>GitHub</a> under the minimally restrictive <a href="http://opensource.org/licenses/MIT" name='newWindow'>MIT open source license</a>.
+				Access to data in Oncoscape is restricted to the same conditions of use as specified in the original data source.
+				</p>
+		  </div>
+		</div>
+	</div>
+		
+ 
+ </div>

--- a/Oncoscape/inst/scripts/Dashboard/widget.html
+++ b/Oncoscape/inst/scripts/Dashboard/widget.html
@@ -96,8 +96,9 @@ ul.UserDocs {
 		<div id="collapse5" class="panel-collapse collapse" role="tabpanel" aria-labelledby="heading5">
 		  <div  id="LegalNotice" class="panel-body">
 			<p>
-				Oncoscape source code is freely available via <a href="http://github.com/oncoscape" name='newWindow'>GitHub</a> under the minimally restrictive <a href="http://opensource.org/licenses/MIT" name='newWindow'>MIT open source license</a>.
+				Oncoscape source code is freely available via <a href="http://github.com/FredHutch/oncoscape" name='newWindow'>GitHub</a> under the minimally restrictive <a href="http://opensource.org/licenses/MIT" name='newWindow'>MIT open source license</a>.
 				Access to data in Oncoscape is restricted to the same conditions of use as specified in the original data source.
+				<br/>By using this site, you agree to follow and be bound by the <a href="http://www.fredhutch.org/en/util/terms-privacy.html" name='newWindow'>terms of use and privacy policy</a>. If you do not agree with any of the terms, please do not use this site.
 				</p>
 		  </div>
 		</div>

--- a/Oncoscape/inst/scripts/apps/oncoscape/widget.html
+++ b/Oncoscape/inst/scripts/apps/oncoscape/widget.html
@@ -5,6 +5,7 @@
 
 
 <script>
+include(../../Dashboard/Module.js)
 include(../../datasets/Module.js)
 include(../../patientHistory/Module.js)
 include(../../patientTimelines/Module.js)
@@ -14,6 +15,7 @@ include(../../gbmPathways/Test.js)
 include(../../survival/Module.js)
 include(../../pca/Module.js)
 include(../../plsr/Module.js)
+include(../../oncoprint/Module.js)
 include(../../linkout/Module.js)
 include(Test.js)
 
@@ -26,6 +28,7 @@ include(Test.js)
 
 <div id="oncoscapeTabs">
    <ul>
+     <li><a href="#DashboardDiv">Dashboard</a></li>
      <li><a href="#datasetsDiv">Datasets</a></li>
      <li><a href="#patientHistoryDiv">Patient History</a></li>
      <li><a href="#patientTimeLinesDiv">Timelines</a></li>
@@ -34,9 +37,11 @@ include(Test.js)
      <li><a href="#survivalDiv">Survival</a></li>
      <li><a href="#pcaDiv">PCA</a></li>
      <li><a href="#plsrDiv">PLSR</a></li>
+     <li><a href="#oncoprintDiv">oncoprint</a></li>
 
    </ul>
 
+include(../../Dashboard/widget.html)
 include(../../datasets/widget.html)
 include(../../patientHistory/widget.html)
 include(../../patientTimelines/widget.html)
@@ -45,6 +50,7 @@ include(../../markersAndSamples/widget.html)
 include(../../survival/widget.html)
 include(../../pca/widget.html)
 include(../../plsr/widget.html)
+include(../../oncoprint/widget.html)
 
 </div>
 
@@ -52,5 +58,11 @@ include(../../plsr/widget.html)
 	<span style="float:left; width:33%">
 	  <a href="http://www.fredhutch.org" target="_blank"><img width="235" height="80" src="http://oncoscape.sttrcancer.org/oncoscape/images/FredHutch_h_tag_4col_RBG_tm.png" alt="Fred Hutch"/></a>
 	</span>
+
+    <span id="githubIssues" style="float:right; margin:10px" title="GitHub Help Wanted Issues">
+       <a href="https://github.com/FredHutch/Oncoscape/labels/help%20wanted" target="_blank" >
+          <img width="40" src="http://oncoscape.sttrcancer.org/oncoscape/images/GitHub-Mark-120px-plus.png"
+          alt="GitHub Issues" data-canonical-src="http://oncoscape.sttrcancer.org/oncoscape/images/GitHub-Mark-120px-plus.png"></a>
+    </span>
 
 </div>

--- a/Oncoscape/inst/scripts/datasets/Module.js
+++ b/Oncoscape/inst/scripts/datasets/Module.js
@@ -103,15 +103,14 @@ function selectManifest(event)
 {
    selectedDataSet = datasetMenu.val();
    console.log("dataset '" + selectedDataSet + "'");
+   $("#datasetsManifestTable").css("display", "none");
 
    if(selectedDataSet === ""){
       $("#datasetInstructions").css("display", "block");
-      $("#datasetsManifestTable").css("display", "none");
       hub.disableButton(useThisDatasetButton);
       }
     else{
       $("#datasetInstructions").css("display", "none");
-      $("#datasetsManifestTable").css("display", "block");
       requestDataSetSummary(selectedDataSet);
     }
 
@@ -164,6 +163,8 @@ function requestDataSetSummary(dataSetName)
 //----------------------------------------------------------------------------------------------------
 function displayDataManifest(msg)
 {
+   $("#datasetsManifestTable").css("display", "block");
+
    var payload = msg.payload;
    var tblColumnNames = payload.colnames;
 

--- a/Oncoscape/inst/scripts/datasets/Module.js
+++ b/Oncoscape/inst/scripts/datasets/Module.js
@@ -224,7 +224,7 @@ function specifyCurrentDataset()
 {
    console.log("Module.datasets 'Use Dataset' button clicked, specifyCurrentDataset: " + selectedDataSet);
  
-   hub.disableAllTabsExcept([thisModulesOutermostDiv, "userDataStoreDiv", "ericTestDiv"]);
+   hub.disableAllTabsExcept([thisModulesOutermostDiv, "userDataStoreDiv", "ericTestDiv", "DashboardDiv"]);
    $("#loadingDatasetMessage").css("display", "inline");
 	
    var msg = {cmd: "specifyCurrentDataset",  callback: "datasetSpecified", 

--- a/Oncoscape/inst/scripts/datasets/widget.html
+++ b/Oncoscape/inst/scripts/datasets/widget.html
@@ -9,7 +9,7 @@
      <button id="selectDatasetButton">Use Dataset</button>
 	 <span id="loadingDatasetMessage" style="display:none; margin-left:10px">Loading Dataset...</span>
      <select type="button" id="datasetsSendSelectionsMenu" style="float:right; margin:15px; display: none"></select>
-    <div id="oncoscapeLogo" style="float:right; margin-right:0.5em">	<img width="175" src="http://oncoscape.sttrcancer.org/oncoscape/images/oncoscape_logo_TM.png" alt="Oncoscape"/></div>
+
   </div>
 
    <div id="dataSetNamesOutputDiv" style="margin: 20px;"></div>

--- a/Oncoscape/inst/scripts/patientTimelines/Module.js
+++ b/Oncoscape/inst/scripts/patientTimelines/Module.js
@@ -262,14 +262,14 @@ var TimeLineModule = (function () {
 		  return;
 		  }
    
-	   createTimelinesObjectOnServer(dataPackageName, dataName);
+	   createTimelinesObjectOnServer();
 
 	} // datasetSpecified
 //--------------------------------------------------------------------------------------------
-	function createTimelinesObjectOnServer(dataPackageName, dataName)
+	function createTimelinesObjectOnServer()
 	{
-	  console.log("create Timelines on server " + dataPackageName + ": " + dataName);
-	  payload = {dataPackage: dataPackageName, dataName: dataName};
+	  console.log("create Timelines on server ");
+	  payload = "";
 	  msg = {cmd: "createTimelines", callback: "DisplayPatientTimeLine", status: "request", payload: payload};
 	  msg.json = JSON.stringify(msg);
 	  hub.send(msg.json);

--- a/Oncoscape/inst/unitTests/testWebSocketOperations.py
+++ b/Oncoscape/inst/unitTests/testWebSocketOperations.py
@@ -243,7 +243,7 @@ def test_histogramCoordinatesDEMOdz_mrna():
 
 # testHistogramCoordinatesDEMOdz_mrna
 #------------------------------------------------------------------------------------------------------------------------
-def test_specifyCurrentDataset():
+def test_specifyCurrentDataset_GBM():
 
   "set current dataset, with legal value, with a nonsensical one"
 
@@ -251,19 +251,6 @@ def test_specifyCurrentDataset():
 
   cmd = "specifyCurrentDataset"
   callback = "datasetSpecified"
-  dataset = "DEMOdz";
-  payload = dataset
-  
-     # set a legitimate dataset
-  msg = dumps({"cmd": cmd, "status": "request", "callback": callback, "payload": payload})
-  ws.send(msg)
-  result = loads(ws.recv())
-  payload = result["payload"]
-  assert(payload.keys() == ['datasetName', 'mtx', 'rownames', 'colnames'])
-  assert(payload["rownames"][0:2] == ['mtx.mrna.ueArray.RData', 'mtx.mrna.bc.RData'])
-  assert(result["cmd"] == callback)
-  
-     # set another legitimate dataset
   dataset = "TCGAgbm";
   payload = dataset
   
@@ -1182,6 +1169,24 @@ def test_pcaCalculate():
 def test_plsr():
 
   print "--- test_plsr"
+
+   #------------------------------------------------------------
+   # first specify currentDataSet
+   #------------------------------------------------------------
+  cmd = "specifyCurrentDataset"
+  callback = "datasetSpecified"
+  dataset = "DEMOdz";
+  payload = dataset
+  
+     # set a legitimate dataset
+  msg = dumps({"cmd": cmd, "status": "request", "callback": callback, "payload": payload})
+  ws.send(msg)
+  result = loads(ws.recv())
+  
+  assert result["payload"]["datasetName"] == dataset;
+  assert result["cmd"] == callback
+  assert result["status"] == "success"
+
 
   test_plsrCreateWithDataSet()
   test_plsrSummarizePLSRPatientAttributes()


### PR DESCRIPTION
### Web links
1. Landing page is now the old dashboard with the oncoscape logo, github "fork me ribbon"
2. Github mark is added to the bottom right of each page linking to the help-wanted issues.

### Data Package Loading
1. .loadDataPackages within the OncoDev14.R file, which is called as part of the Oncoscape constructor, no longer loads and constructs all the data packages within the parent environment upon launching Oncoscape.  Instead it stores the default SttrDataPackage constructor for each dataset name: datasets[['%s']] <- SttrDataPackage().  While just having the dataset name in the “datasets” environment is probably sufficient at this step, using the base constructor may be helpful for transitioning to the indirect data calls for later. 
2. The data package is loaded and constructed when the manifest file is called (from the getDataManifest function in wsDatasets.R).  The data package itself is stored within the “datasets” environment defined in OncoDev14.R just as before, i.e. datasets[[datasetName]] <- datasetName().  The manifest table will have display = none until a proper manifest is returned.  If we wanted to reclaim any memory, we would be able to detach the current dataset (or stale ones) before loading a new one here.
3. The state environment no longer holds the constructed data as well, but just the name of the dataset loaded, i.e. state[[datasetName]] <- datasetName.  This is used to determine which datasets have been loaded and constructed.
