### PR TITLE
Use HTTPS for cloning

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,11 +15,19 @@ If you haven't already, start by signing up for a [GitHub account](https://githu
 You can clone this repository locally from GitHub using the "Clone in Desktop" 
 button from the main project site, or run this command in the Git Shell:
 
+`git clone https://github.com/FredHutch/Oncoscape.git Oncoscape`
+
+Or if you're using SSH
+
 `git clone git@github.com:FredHutch/oncoscape.git Oncoscape`
 
 If you want to make contributions to the project, 
 [forking the project](https://help.github.com/articles/fork-a-repo) is the 
 easiest way to do this. You can then clone down your fork instead:
+
+`git clone https://github.com/MY-USERNAME-HERE/Oncoscape.git Oncoscape`
+
+Or if you're using SSH
 
 `git clone git@github.com:MY-USERNAME-HERE/Oncoscape.git Oncoscape`
 


### PR DESCRIPTION
GitHub generally recommends people use HTTPS to clone repositories. It's easier to set since Git comes with HTTP credential providers. I've kept the SSH URL for those who are using SSH and have set that all up.