### PR TITLE
Ensure LF line endings for .sh and .R files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+# Set the default behavior, in case people don't have core.autocrlf set
+
+* text=auto
+
+# Text files that must have LF on checkout
+
+*.sh  text eol=lf
+*.R   text eol=lf
+
+# Files that are truly binary
+
+*.RData binary
+*.pdf   binary
+*.png   binary
+*.gif   binary
+*.jpg   binary


### PR DESCRIPTION
If a Windows developer has `autocrlf=true`, when they checkout files, `LF` will be converted to `CRLF`. This is no good for the `.sh` and `.R` scripts because they're run in a Cygwin environment which expects `LF` line endings. It gets pretty upset about the extra `CR` it wasn't expecting.

This PR adds a `.gitattributes` file which uses the `autocrlf` behavior for `text` files, but not for `.sh` and `.R` files.

It also makes sure we don't interpret `.RData` (and other binary file types such as `.pdf`) as text. C'mon Git, you know as well as I do those are binary files. But I'll tell you anyways.