### PR TITLE
adjust .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,9 @@
 server/node_modules/*
+.git
+client
+README.md
+INSTALL.md
+DOCKER.md
+CONTRIBUTING.md
+cheatsheet.md
+LICENSE


### PR DESCRIPTION
added .git and other files/dirs not needed by docker. This should speed things up a bit as .git is currently 1.6GB