### PR TITLE
Added long running test branch config to circle config

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -28,3 +28,12 @@ deployment:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
       - docker push fredhutch/oncoscape:develop; sleep 60
       - curl -X POST $DEPLOY_DOCKER_DEVELOP
+
+  test:
+    branch: test
+    commands:
+      - docker tag fredhutch/oncoscape:$CIRCLE_SHA1 fredhutch/oncoscape:test
+      - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+      - docker push fredhutch/oncoscape:test; sleep 60
+      - curl -X POST $DEPLOY_DOCKER_TEST
+


### PR DESCRIPTION
The develop branch will be the starting origin for the long running "test" branch, so the develop branch must also contain the test branch circle build and deployment configuration.